### PR TITLE
Fix create-event to schedule reliably with human dates and recover existing slots

### DIFF
--- a/app/api/billing/portal-session/route.ts
+++ b/app/api/billing/portal-session/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { createClient } from "@/lib/supabase/server";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+if (!stripeSecretKey) {
+  throw new Error("STRIPE_SECRET_KEY não configurada.");
+}
+
+if (!siteUrl) {
+  throw new Error("NEXT_PUBLIC_SITE_URL não configurada.");
+}
+
+const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2025-02-24.acacia",
+});
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError) {
+      return NextResponse.json({ error: authError.message }, { status: 401 });
+    }
+
+    if (!user) {
+      return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("stripe_customer_id")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    if (!profile?.stripe_customer_id) {
+      return NextResponse.json({ error: "Cliente Stripe não encontrado" }, { status: 404 });
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: profile.stripe_customer_id,
+      return_url: `${siteUrl}/dashboard`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : "Erro inesperado ao criar sessão do portal de cobrança.";
+    console.error("[PORTAL_ERROR]:", err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/calendar/available-days-bot/route.ts
+++ b/app/api/calendar/available-days-bot/route.ts
@@ -1,0 +1,434 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+function safeDecode(input: string) {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    return input;
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+type ScheduleSettings = {
+  timezone?: string;
+  work_days?: string[];
+  morning_start?: string;
+  morning_end?: string;
+  afternoon_start?: string;
+  afternoon_end?: string;
+  slot_minutes?: number;
+};
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new NextResponse(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      Pragma: "no-cache",
+      Expires: "0",
+      "Surrogate-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, x-api-key",
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return jsonResponse({ ok: true });
+}
+
+function pad2(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+function normalizeText(s: string) {
+  return s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function parseDateFlexible(dateStr: string): { y: number; mo: number; d: number } | null {
+  if (!dateStr) return null;
+
+  const withoutTime = dateStr.split("T")[0].split(" ")[0].trim();
+  let s = withoutTime.replace(/[{}]/g, "").trim();
+  s = normalizeText(s).replace(/\s/g, "").replace(/["']/g, "");
+
+  if (s === "hoje" || s === "hoj") {
+    const today = new Date();
+    return { y: today.getFullYear(), mo: today.getMonth() + 1, d: today.getDate() };
+  }
+  if (s === "amanha" || s === "amanhã" || s === "amanh") {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return { y: tomorrow.getFullYear(), mo: tomorrow.getMonth() + 1, d: tomorrow.getDate() };
+  }
+
+  let m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (m) return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+
+  m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  m = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  return null;
+}
+
+function ymdToString(ymd: { y: number; mo: number; d: number }) {
+  return `${ymd.y}-${pad2(ymd.mo)}-${pad2(ymd.d)}`;
+}
+
+function addDaysToYMD(ymd: { y: number; mo: number; d: number }, add: number) {
+  const dt = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d));
+  dt.setUTCDate(dt.getUTCDate() + add);
+  return { y: dt.getUTCFullYear(), mo: dt.getUTCMonth() + 1, d: dt.getUTCDate() };
+}
+
+function formatDDMM(ymdStr: string) {
+  const [, m, d] = ymdStr.split("-");
+  return `${d}/${m}`;
+}
+
+function isValidHHMM(s: string) {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(s);
+}
+
+function getOffsetMinutes(timeZone: string, dateUTC: Date) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  const parts = fmt.formatToParts(dateUTC);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+
+  const asIfUTC = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second)
+  );
+
+  return (asIfUTC - dateUTC.getTime()) / 60000;
+}
+
+function ymdToUTCRange(timeZone: string, ymd: { y: number; mo: number; d: number }) {
+  const utcMidnight = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d, 0, 0, 0));
+  const offset = getOffsetMinutes(timeZone, utcMidnight);
+  const startUTC = new Date(utcMidnight.getTime() - offset * 60000);
+  const endUTC = new Date(startUTC.getTime() + 86400000);
+  return { startUTC, endUTC };
+}
+
+function buildSlotsForDay(settings: Required<ScheduleSettings>) {
+  const slots: string[] = [];
+
+  const addRange = (start: string, end: string) => {
+    const [sh, sm] = start.split(":").map(Number);
+    const [eh, em] = end.split(":").map(Number);
+
+    let cur = sh * 60 + sm;
+    const endMin = eh * 60 + em;
+
+    while (cur + settings.slot_minutes <= endMin) {
+      const hh = Math.floor(cur / 60);
+      const mm = cur % 60;
+      slots.push(`${pad2(hh)}:${pad2(mm)}`);
+      cur += settings.slot_minutes;
+    }
+  };
+
+  addRange(settings.morning_start, settings.morning_end);
+  addRange(settings.afternoon_start, settings.afternoon_end);
+
+  return slots;
+}
+
+function getTodayYMDInTZ(timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = fmt.formatToParts(new Date());
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.year}-${map.month}-${map.day}`;
+}
+
+function getLocalHHMM(date: Date, timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const parts = fmt.formatToParts(date);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.hour}:${map.minute}`;
+}
+
+function getWeekdayKeyInTZ(ymdStr: string, timeZone: string): string {
+  const [y, mo, d] = ymdStr.split("-").map(Number);
+  const utcMid = new Date(Date.UTC(y, mo - 1, d, 12, 0, 0));
+  const fmt = new Intl.DateTimeFormat("en-US", { timeZone, weekday: "short" });
+  const wd = fmt.format(utcMid).toLowerCase();
+  return wd.slice(0, 3);
+}
+
+function isYmdBefore(a: string, b: string) {
+  return a < b;
+}
+
+async function fetchAppointmentsSafe(
+  adminSupabase: any,
+  projectId: string,
+  isoStart: string,
+  isoEnd: string
+): Promise<{ iso: string }[]> {
+  let res = await adminSupabase
+    .from("appointments")
+    .select("start_datetime")
+    .eq("project_id", projectId)
+    .gte("start_datetime", isoStart)
+    .lt("start_datetime", isoEnd);
+
+  if (!res.error) {
+    return (res.data || [])
+      .map((r: { start_datetime?: string }) => ({ iso: r.start_datetime || "" }))
+      .filter((x: { iso: string }) => !!x.iso);
+  }
+
+  res = await adminSupabase
+    .from("appointments")
+    .select("start_time")
+    .eq("project_id", projectId)
+    .gte("start_time", isoStart)
+    .lt("start_time", isoEnd);
+
+  if (!res.error) {
+    return (res.data || [])
+      .map((r: { start_time?: string }) => ({ iso: r.start_time || "" }))
+      .filter((x: { iso: string }) => !!x.iso);
+  }
+
+  throw new Error(res.error?.message || "Erro ao consultar appointments");
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const adminSupabase = createAdminClient();
+    const url = new URL(req.url);
+
+    const keyFromQuery = safeDecode(url.searchParams.get("key") || "").trim();
+    const authHeader = req.headers.get("Authorization") || req.headers.get("x-api-key") || "";
+    const rawKey = keyFromQuery ? keyFromQuery : authHeader.replace("Bearer ", "").trim();
+
+    if (!rawKey) return jsonResponse({ success: false, error: "No API Key" }, 401);
+
+    const hash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+    const { data: apiKeyData } = await adminSupabase
+      .from("api_keys")
+      .select("project_id")
+      .eq("key_hash", hash)
+      .single();
+
+    if (!apiKeyData) return jsonResponse({ success: false, error: "Invalid Key" }, 401);
+
+    const defaults: Required<ScheduleSettings> = {
+      timezone: "America/Sao_Paulo",
+      work_days: ["mon", "tue", "wed", "thu", "fri"],
+      morning_start: "08:00",
+      morning_end: "11:00",
+      afternoon_start: "13:00",
+      afternoon_end: "17:00",
+      slot_minutes: 60,
+    };
+
+    const { data: dbSettings } = await adminSupabase
+      .from("schedule_settings")
+      .select("*")
+      .eq("project_id", apiKeyData.project_id)
+      .maybeSingle();
+
+    const settings: Required<ScheduleSettings> = { ...defaults, ...(dbSettings ?? {}) };
+    const allSlots = buildSlotsForDay(settings);
+
+    const startParam = safeDecode(
+      url.searchParams.get("start") ||
+        url.searchParams.get("data") ||
+        url.searchParams.get("data_agendamento") ||
+        url.searchParams.get("data_atendimento") ||
+        ""
+    ).trim();
+
+    const days = Math.min(Number(url.searchParams.get("days") || "7"), 60);
+    const limitPerDay = Math.min(Number(url.searchParams.get("limit_per_day") || "3"), 10);
+
+    const fromParamRaw = safeDecode(url.searchParams.get("from") || "").trim();
+    const fromHHMM = isValidHHMM(fromParamRaw) ? fromParamRaw : null;
+
+    const todayStr = getTodayYMDInTZ(settings.timezone);
+    const nowHHMM = getLocalHHMM(new Date(), settings.timezone);
+
+    const startRaw = startParam || todayStr || "hoje";
+    const parsed = parseDateFlexible(startRaw);
+    if (!parsed) return jsonResponse({ success: false, error: `Data inválida: ${startRaw}` }, 400);
+
+    let startYMD = parsed;
+    let startYMDStr = ymdToString(startYMD);
+    if (isYmdBefore(startYMDStr, todayStr)) {
+      const [y, mo, d] = todayStr.split("-").map(Number);
+      startYMD = { y, mo, d };
+      startYMDStr = todayStr;
+    }
+
+    const firstRange = ymdToUTCRange(settings.timezone, startYMD);
+    const lastYMD = addDaysToYMD(startYMD, days - 1);
+    const lastRange = ymdToUTCRange(settings.timezone, lastYMD);
+
+    const isoStart = firstRange.startUTC.toISOString();
+    const isoEnd = lastRange.endUTC.toISOString();
+
+    const appts = await fetchAppointmentsSafe(adminSupabase, apiKeyData.project_id, isoStart, isoEnd);
+
+    const occupiedByDay: Record<string, Set<string>> = {};
+
+    for (const a of appts) {
+      const dt = new Date(a.iso);
+
+      const fmtDay = new Intl.DateTimeFormat("en-CA", {
+        timeZone: settings.timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
+      const fmtTime = new Intl.DateTimeFormat("en-US", {
+        timeZone: settings.timezone,
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+
+      const dayParts = fmtDay.formatToParts(dt);
+      const timeParts = fmtTime.formatToParts(dt);
+
+      const dm: Record<string, string> = {};
+      const tm: Record<string, string> = {};
+      for (const p of dayParts) dm[p.type] = p.value;
+      for (const p of timeParts) tm[p.type] = p.value;
+
+      const ymd = `${dm.year}-${dm.month}-${dm.day}`;
+      const hhmm = `${tm.hour}:${tm.minute}`;
+
+      if (!occupiedByDay[ymd]) occupiedByDay[ymd] = new Set<string>();
+      occupiedByDay[ymd].add(hhmm);
+    }
+
+    const results: Array<{ date: string; available_times: string[]; available_times_text: string }> = [];
+    let firstAvailableDate: string | null = null;
+
+    const endOfDayCutoff = settings.afternoon_end;
+
+    for (let i = 0; i < days; i++) {
+      const ymdObj = addDaysToYMD(startYMD, i);
+      const dateStr = ymdToString(ymdObj);
+
+      const wd = getWeekdayKeyInTZ(dateStr, settings.timezone);
+      if (!settings.work_days.includes(wd)) continue;
+
+      if (dateStr === todayStr && nowHHMM >= endOfDayCutoff) continue;
+
+      const minHHMM = dateStr === todayStr ? (fromHHMM ? fromHHMM : nowHHMM) : null;
+
+      const occupied = occupiedByDay[dateStr] || new Set<string>();
+      const candidateSlots = minHHMM ? allSlots.filter((t) => t > minHHMM) : allSlots;
+      const available = candidateSlots.filter((t) => !occupied.has(t));
+
+      if (available.length === 0) continue;
+
+      const preferAfternoon = i % 2 === 1;
+      const morning = available.filter((t) => t >= settings.morning_start && t < settings.morning_end);
+      const afternoon = available.filter(
+        (t) => t >= settings.afternoon_start && t < settings.afternoon_end
+      );
+
+      const pickBase = preferAfternoon
+        ? afternoon.length
+          ? afternoon
+          : morning
+        : morning.length
+          ? morning
+          : afternoon;
+
+      const finalSlots = pickBase.slice(0, limitPerDay);
+      if (finalSlots.length === 0) continue;
+
+      if (!firstAvailableDate) firstAvailableDate = dateStr;
+
+      results.push({
+        date: dateStr,
+        available_times: finalSlots,
+        available_times_text: finalSlots.join(", "),
+      });
+
+      if (results.length >= 10) break;
+    }
+
+    const availableDaysInline = results
+      .map((d) => `${formatDDMM(d.date)}: ${d.available_times_text}`)
+      .join(" | ");
+
+    const simple = (url.searchParams.get("simple") || "").trim() === "1";
+
+    if (simple) {
+      return jsonResponse({
+        success: true,
+        has_availability: results.length > 0,
+        tentativa_data: firstAvailableDate || "",
+        available_days_inline: availableDaysInline,
+        horarios_disponiveis_inline: availableDaysInline,
+        available_days_text: availableDaysInline,
+        horarios_disponiveis: availableDaysInline,
+        message: results.length > 0 ? "Disponibilidade encontrada." : "Sem horários no período.",
+      });
+    }
+
+    return jsonResponse({
+      timezone: settings.timezone,
+      start: ymdToString(startYMD),
+      days,
+      results,
+      available_days_inline: availableDaysInline,
+      available_days_text: availableDaysInline,
+      first_available_date: firstAvailableDate || "",
+      horarios_disponiveis_inline: availableDaysInline,
+      horarios_disponiveis: availableDaysInline,
+      tentativa_data: firstAvailableDate || "",
+      success: true,
+      has_availability: results.length > 0,
+      message: results.length > 0 ? "Disponibilidade encontrada." : "Sem horários no período.",
+    });
+  } catch (err: any) {
+    return jsonResponse({ success: false, error: err?.message || "Internal error" }, 500);
+  }
+}

--- a/app/api/calendar/available-days/route.ts
+++ b/app/api/calendar/available-days/route.ts
@@ -1,0 +1,383 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+function safeDecode(input: string) {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    return input;
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+type ScheduleSettings = {
+  timezone?: string;
+  work_days?: string[];
+  morning_start?: string;
+  morning_end?: string;
+  afternoon_start?: string;
+  afternoon_end?: string;
+  slot_minutes?: number;
+};
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new NextResponse(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      Pragma: "no-cache",
+      Expires: "0",
+      "Surrogate-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, x-api-key",
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return jsonResponse({ ok: true });
+}
+
+function pad2(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+function normalizeText(s: string) {
+  return s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function parseDateFlexible(dateStr: string): { y: number; mo: number; d: number } | null {
+  if (!dateStr) return null;
+
+  const withoutTime = dateStr.split("T")[0].split(" ")[0].trim();
+  let s = withoutTime.replace(/[{}]/g, "").trim();
+  s = normalizeText(s).replace(/\s/g, "").replace(/["']/g, "");
+
+  if (s === "hoje" || s === "hoj") {
+    const today = new Date();
+    return { y: today.getFullYear(), mo: today.getMonth() + 1, d: today.getDate() };
+  }
+  if (s === "amanha" || s === "amanhã" || s === "amanh") {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return { y: tomorrow.getFullYear(), mo: tomorrow.getMonth() + 1, d: tomorrow.getDate() };
+  }
+
+  let m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (m) return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+
+  m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  m = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  return null;
+}
+
+function ymdToString(ymd: { y: number; mo: number; d: number }) {
+  return `${ymd.y}-${pad2(ymd.mo)}-${pad2(ymd.d)}`;
+}
+
+function addDaysToYMD(ymd: { y: number; mo: number; d: number }, add: number) {
+  const dt = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d));
+  dt.setUTCDate(dt.getUTCDate() + add);
+  return { y: dt.getUTCFullYear(), mo: dt.getUTCMonth() + 1, d: dt.getUTCDate() };
+}
+
+function formatDDMM(ymdStr: string) {
+  const [, m, d] = ymdStr.split("-");
+  return `${d}/${m}`;
+}
+
+function isValidHHMM(s: string) {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(s);
+}
+
+function getOffsetMinutes(timeZone: string, dateUTC: Date) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  const parts = fmt.formatToParts(dateUTC);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+
+  const asIfUTC = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second)
+  );
+
+  return (asIfUTC - dateUTC.getTime()) / 60000;
+}
+
+function ymdToUTCRange(timeZone: string, ymd: { y: number; mo: number; d: number }) {
+  const utcMidnight = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d, 0, 0, 0));
+  const offset = getOffsetMinutes(timeZone, utcMidnight);
+  const startUTC = new Date(utcMidnight.getTime() - offset * 60000);
+  const endUTC = new Date(startUTC.getTime() + 86400000);
+  return { startUTC, endUTC };
+}
+
+function buildSlotsForDay(settings: Required<ScheduleSettings>) {
+  const slots: string[] = [];
+
+  const addRange = (start: string, end: string) => {
+    const [sh, sm] = start.split(":").map(Number);
+    const [eh, em] = end.split(":").map(Number);
+
+    let cur = sh * 60 + sm;
+    const endMin = eh * 60 + em;
+
+    while (cur + settings.slot_minutes <= endMin) {
+      const hh = Math.floor(cur / 60);
+      const mm = cur % 60;
+      slots.push(`${pad2(hh)}:${pad2(mm)}`);
+      cur += settings.slot_minutes;
+    }
+  };
+
+  addRange(settings.morning_start, settings.morning_end);
+  addRange(settings.afternoon_start, settings.afternoon_end);
+
+  return slots;
+}
+
+function getTodayYMDInTZ(timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = fmt.formatToParts(new Date());
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.year}-${map.month}-${map.day}`;
+}
+
+function getLocalHHMM(date: Date, timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const parts = fmt.formatToParts(date);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.hour}:${map.minute}`;
+}
+
+function getWeekdayKeyInTZ(ymdStr: string, timeZone: string): string {
+  const [y, mo, d] = ymdStr.split("-").map(Number);
+  const utcMid = new Date(Date.UTC(y, mo - 1, d, 12, 0, 0));
+  const fmt = new Intl.DateTimeFormat("en-US", { timeZone, weekday: "short" });
+  const wd = fmt.format(utcMid).toLowerCase();
+  return wd.slice(0, 3);
+}
+
+function isYmdBefore(a: string, b: string) {
+  return a < b;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const adminSupabase = createAdminClient();
+    const url = new URL(req.url);
+
+    const simple = (url.searchParams.get("simple") || "").trim() === "1";
+
+    const keyFromQuery = safeDecode(url.searchParams.get("key") || "").trim();
+    const authHeader = req.headers.get("Authorization") || req.headers.get("x-api-key") || "";
+    const rawKey = keyFromQuery ? keyFromQuery : authHeader.replace("Bearer ", "").trim();
+
+    if (!rawKey) return jsonResponse({ success: false, error: "No API Key" }, 401);
+
+    const hash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+    const { data: apiKeyData } = await adminSupabase
+      .from("api_keys")
+      .select("project_id")
+      .eq("key_hash", hash)
+      .single();
+
+    if (!apiKeyData) return jsonResponse({ success: false, error: "Invalid Key" }, 401);
+
+    const defaults: Required<ScheduleSettings> = {
+      timezone: "America/Sao_Paulo",
+      work_days: ["mon", "tue", "wed", "thu", "fri"],
+      morning_start: "08:00",
+      morning_end: "12:00",
+      afternoon_start: "13:00",
+      afternoon_end: "18:00",
+      slot_minutes: 30,
+    };
+
+    const { data: dbSettings } = await adminSupabase
+      .from("schedule_settings")
+      .select("*")
+      .eq("project_id", apiKeyData.project_id)
+      .maybeSingle();
+
+    const settings: Required<ScheduleSettings> = { ...defaults, ...(dbSettings ?? {}) };
+    const allSlots = buildSlotsForDay(settings);
+
+    const startParam = safeDecode(
+      url.searchParams.get("start") ||
+        url.searchParams.get("data") ||
+        url.searchParams.get("data_agendamento") ||
+        url.searchParams.get("data_atendimento") ||
+        ""
+    ).trim();
+
+    const days = Math.min(Number(url.searchParams.get("days") || "30"), 60);
+    const limitPerDay = Math.min(Number(url.searchParams.get("limit_per_day") || "3"), 10);
+
+    const fromParamRaw = safeDecode(url.searchParams.get("from") || "").trim();
+    const fromHHMM = isValidHHMM(fromParamRaw) ? fromParamRaw : null;
+
+    const todayStr = getTodayYMDInTZ(settings.timezone);
+    const nowHHMM = getLocalHHMM(new Date(), settings.timezone);
+
+    const startRaw = startParam || todayStr || "hoje";
+    const parsed = parseDateFlexible(startRaw);
+    if (!parsed) return jsonResponse({ success: false, error: `Data inválida: ${startRaw}` }, 400);
+
+    let startYMD = parsed;
+    let startYMDStr = ymdToString(startYMD);
+    if (isYmdBefore(startYMDStr, todayStr)) {
+      const [y, mo, d] = todayStr.split("-").map(Number);
+      startYMD = { y, mo, d };
+      startYMDStr = todayStr;
+    }
+
+    const results: Array<{ date: string; available_times: string[]; available_times_text: string }> = [];
+    let firstAvailableDate: string | null = null;
+
+    const endOfDayCutoff = settings.afternoon_end;
+
+    for (let i = 0; i < days; i++) {
+      const ymd = addDaysToYMD(startYMD, i);
+      const dateStr = ymdToString(ymd);
+
+      const wd = getWeekdayKeyInTZ(dateStr, settings.timezone);
+      if (!settings.work_days.includes(wd)) continue;
+
+      if (dateStr === todayStr && nowHHMM >= endOfDayCutoff) continue;
+
+      const minHHMM = dateStr === todayStr ? (fromHHMM ? fromHHMM : nowHHMM) : null;
+      const midUTC = ymdToUTCRange(settings.timezone, ymd);
+
+      const { data: events, error: evErr } = await adminSupabase
+        .from("appointments")
+        .select("start_datetime")
+        .eq("project_id", apiKeyData.project_id)
+        .gte("start_datetime", midUTC.startUTC.toISOString())
+        .lt("start_datetime", midUTC.endUTC.toISOString());
+
+      if (evErr) throw new Error(evErr.message);
+
+      const occupied = new Set<string>();
+
+      for (const ev of events || []) {
+        const dt = new Date((ev as { start_datetime: string }).start_datetime);
+
+        const fmt = new Intl.DateTimeFormat("en-US", {
+          timeZone: settings.timezone,
+          hour12: false,
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        const parts = fmt.formatToParts(dt);
+        const map: Record<string, string> = {};
+        for (const p of parts) map[p.type] = p.value;
+
+        occupied.add(`${map.hour}:${map.minute}`);
+      }
+
+      const candidateSlots = minHHMM ? allSlots.filter((t) => t > minHHMM) : allSlots;
+      const available = candidateSlots.filter((t) => !occupied.has(t));
+
+      if (available.length === 0) continue;
+
+      const preferAfternoon = i % 2 === 1;
+      const morning = available.filter((t) => t >= settings.morning_start && t < settings.morning_end);
+      const afternoon = available.filter(
+        (t) => t >= settings.afternoon_start && t < settings.afternoon_end
+      );
+
+      const pickBase = preferAfternoon
+        ? afternoon.length
+          ? afternoon
+          : morning
+        : morning.length
+          ? morning
+          : afternoon;
+
+      const finalSlots = pickBase.slice(0, limitPerDay);
+      if (finalSlots.length === 0) continue;
+
+      if (!firstAvailableDate) firstAvailableDate = dateStr;
+
+      results.push({
+        date: dateStr,
+        available_times: finalSlots,
+        available_times_text: finalSlots.join(", "),
+      });
+
+      if (results.length >= 10) break;
+    }
+
+    const availableDaysInline = results
+      .map((d) => `${formatDDMM(d.date)}: ${d.available_times_text}`)
+      .join(" | ");
+
+    if (simple) {
+      return jsonResponse({
+        success: true,
+        horarios_disponiveis_inline: availableDaysInline,
+        horarios_disponiveis: availableDaysInline,
+        available_days_text: availableDaysInline,
+        tentativa_data: firstAvailableDate || "",
+        first_available_date: firstAvailableDate || "",
+        has_availability: results.length > 0,
+      });
+    }
+
+    return jsonResponse({
+      timezone: settings.timezone,
+      start: ymdToString(startYMD),
+      days,
+      results,
+      available_days_inline: availableDaysInline,
+      available_days_text: availableDaysInline,
+      first_available_date: firstAvailableDate || "",
+      horarios_disponiveis: availableDaysInline,
+      horarios_disponiveis_inline: availableDaysInline,
+      tentativa_data: firstAvailableDate || "",
+      success: true,
+      has_availability: results.length > 0,
+    });
+  } catch (err: any) {
+    return jsonResponse({ success: false, error: err?.message || "Internal error" }, 500);
+  }
+}

--- a/app/api/calendar/available-times/route.ts
+++ b/app/api/calendar/available-times/route.ts
@@ -1,0 +1,383 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+function safeDecode(input: string) {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    return input;
+  }
+}
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+type ScheduleSettings = {
+  timezone?: string;
+  work_days?: string[];
+  morning_start?: string;
+  morning_end?: string;
+  afternoon_start?: string;
+  afternoon_end?: string;
+  slot_minutes?: number;
+};
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new NextResponse(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      Pragma: "no-cache",
+      Expires: "0",
+      "Surrogate-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, x-api-key",
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return jsonResponse({ ok: true });
+}
+
+function pad2(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+function normalizeText(s: string) {
+  return s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function parseDateFlexible(dateStr: string): { y: number; mo: number; d: number } | null {
+  if (!dateStr) return null;
+
+  const withoutTime = dateStr.split("T")[0].split(" ")[0].trim();
+  let s = withoutTime.replace(/[{}]/g, "").trim();
+  s = normalizeText(s).replace(/\s/g, "").replace(/["']/g, "");
+
+  if (s === "hoje" || s === "hoj") {
+    const today = new Date();
+    return { y: today.getFullYear(), mo: today.getMonth() + 1, d: today.getDate() };
+  }
+  if (s === "amanha" || s === "amanhã" || s === "amanh") {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return { y: tomorrow.getFullYear(), mo: tomorrow.getMonth() + 1, d: tomorrow.getDate() };
+  }
+
+  let m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (m) return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+
+  m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  m = /^(\d{1,2})-(\d{1,2})-(\d{4})$/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+
+  return null;
+}
+
+function ymdToString(ymd: { y: number; mo: number; d: number }) {
+  return `${ymd.y}-${pad2(ymd.mo)}-${pad2(ymd.d)}`;
+}
+
+function addDaysToYMD(ymd: { y: number; mo: number; d: number }, add: number) {
+  const dt = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d));
+  dt.setUTCDate(dt.getUTCDate() + add);
+  return { y: dt.getUTCFullYear(), mo: dt.getUTCMonth() + 1, d: dt.getUTCDate() };
+}
+
+function formatDDMM(ymdStr: string) {
+  const [, m, d] = ymdStr.split("-");
+  return `${d}/${m}`;
+}
+
+function isValidHHMM(s: string) {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(s);
+}
+
+function getOffsetMinutes(timeZone: string, dateUTC: Date) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  const parts = fmt.formatToParts(dateUTC);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+
+  const asIfUTC = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second)
+  );
+
+  return (asIfUTC - dateUTC.getTime()) / 60000;
+}
+
+function ymdToUTCRange(timeZone: string, ymd: { y: number; mo: number; d: number }) {
+  const utcMidnight = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d, 0, 0, 0));
+  const offset = getOffsetMinutes(timeZone, utcMidnight);
+  const startUTC = new Date(utcMidnight.getTime() - offset * 60000);
+  const endUTC = new Date(startUTC.getTime() + 86400000);
+  return { startUTC, endUTC };
+}
+
+function buildSlotsForDay(settings: Required<ScheduleSettings>) {
+  const slots: string[] = [];
+
+  const addRange = (start: string, end: string) => {
+    const [sh, sm] = start.split(":").map(Number);
+    const [eh, em] = end.split(":").map(Number);
+
+    let cur = sh * 60 + sm;
+    const endMin = eh * 60 + em;
+
+    while (cur + settings.slot_minutes <= endMin) {
+      const hh = Math.floor(cur / 60);
+      const mm = cur % 60;
+      slots.push(`${pad2(hh)}:${pad2(mm)}`);
+      cur += settings.slot_minutes;
+    }
+  };
+
+  addRange(settings.morning_start, settings.morning_end);
+  addRange(settings.afternoon_start, settings.afternoon_end);
+
+  return slots;
+}
+
+function getTodayYMDInTZ(timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = fmt.formatToParts(new Date());
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.year}-${map.month}-${map.day}`;
+}
+
+function getLocalHHMM(date: Date, timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const parts = fmt.formatToParts(date);
+  const map: Record<string, string> = {};
+  for (const p of parts) map[p.type] = p.value;
+  return `${map.hour}:${map.minute}`;
+}
+
+function getWeekdayKeyInTZ(ymdStr: string, timeZone: string): string {
+  const [y, mo, d] = ymdStr.split("-").map(Number);
+  const utcMid = new Date(Date.UTC(y, mo - 1, d, 12, 0, 0));
+  const fmt = new Intl.DateTimeFormat("en-US", { timeZone, weekday: "short" });
+  const wd = fmt.format(utcMid).toLowerCase();
+  return wd.slice(0, 3);
+}
+
+function isYmdBefore(a: string, b: string) {
+  return a < b;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const adminSupabase = createAdminClient();
+    const url = new URL(req.url);
+
+    const simple = (url.searchParams.get("simple") || "").trim() === "1";
+
+    const keyFromQuery = safeDecode(url.searchParams.get("key") || "").trim();
+    const authHeader = req.headers.get("Authorization") || req.headers.get("x-api-key") || "";
+    const rawKey = keyFromQuery ? keyFromQuery : authHeader.replace("Bearer ", "").trim();
+
+    if (!rawKey) return jsonResponse({ success: false, error: "No API Key" }, 401);
+
+    const hash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+    const { data: apiKeyData } = await adminSupabase
+      .from("api_keys")
+      .select("project_id")
+      .eq("key_hash", hash)
+      .single();
+
+    if (!apiKeyData) return jsonResponse({ success: false, error: "Invalid Key" }, 401);
+
+    const defaults: Required<ScheduleSettings> = {
+      timezone: "America/Sao_Paulo",
+      work_days: ["mon", "tue", "wed", "thu", "fri"],
+      morning_start: "08:00",
+      morning_end: "12:00",
+      afternoon_start: "13:00",
+      afternoon_end: "18:00",
+      slot_minutes: 30,
+    };
+
+    const { data: dbSettings } = await adminSupabase
+      .from("schedule_settings")
+      .select("*")
+      .eq("project_id", apiKeyData.project_id)
+      .maybeSingle();
+
+    const settings: Required<ScheduleSettings> = { ...defaults, ...(dbSettings ?? {}) };
+    const allSlots = buildSlotsForDay(settings);
+
+    const startParam = safeDecode(
+      url.searchParams.get("start") ||
+        url.searchParams.get("data") ||
+        url.searchParams.get("data_agendamento") ||
+        url.searchParams.get("data_atendimento") ||
+        ""
+    ).trim();
+
+    const days = Math.min(Number(url.searchParams.get("days") || "30"), 60);
+    const limitPerDay = Math.min(Number(url.searchParams.get("limit_per_day") || "3"), 10);
+
+    const fromParamRaw = safeDecode(url.searchParams.get("from") || "").trim();
+    const fromHHMM = isValidHHMM(fromParamRaw) ? fromParamRaw : null;
+
+    const todayStr = getTodayYMDInTZ(settings.timezone);
+    const nowHHMM = getLocalHHMM(new Date(), settings.timezone);
+
+    const startRaw = startParam || todayStr || "hoje";
+    const parsed = parseDateFlexible(startRaw);
+    if (!parsed) return jsonResponse({ success: false, error: `Data inválida: ${startRaw}` }, 400);
+
+    let startYMD = parsed;
+    let startYMDStr = ymdToString(startYMD);
+    if (isYmdBefore(startYMDStr, todayStr)) {
+      const [y, mo, d] = todayStr.split("-").map(Number);
+      startYMD = { y, mo, d };
+      startYMDStr = todayStr;
+    }
+
+    const results: Array<{ date: string; available_times: string[]; available_times_text: string }> = [];
+    let firstAvailableDate: string | null = null;
+
+    const endOfDayCutoff = settings.afternoon_end;
+
+    for (let i = 0; i < days; i++) {
+      const ymd = addDaysToYMD(startYMD, i);
+      const dateStr = ymdToString(ymd);
+
+      const wd = getWeekdayKeyInTZ(dateStr, settings.timezone);
+      if (!settings.work_days.includes(wd)) continue;
+
+      if (dateStr === todayStr && nowHHMM >= endOfDayCutoff) continue;
+
+      const minHHMM = dateStr === todayStr ? (fromHHMM ? fromHHMM : nowHHMM) : null;
+      const midUTC = ymdToUTCRange(settings.timezone, ymd);
+
+      const { data: events, error: evErr } = await adminSupabase
+        .from("appointments")
+        .select("start_datetime")
+        .eq("project_id", apiKeyData.project_id)
+        .gte("start_datetime", midUTC.startUTC.toISOString())
+        .lt("start_datetime", midUTC.endUTC.toISOString());
+
+      if (evErr) throw new Error(evErr.message);
+
+      const occupied = new Set<string>();
+
+      for (const ev of events || []) {
+        const dt = new Date((ev as { start_datetime: string }).start_datetime);
+
+        const fmt = new Intl.DateTimeFormat("en-US", {
+          timeZone: settings.timezone,
+          hour12: false,
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        const parts = fmt.formatToParts(dt);
+        const map: Record<string, string> = {};
+        for (const p of parts) map[p.type] = p.value;
+
+        occupied.add(`${map.hour}:${map.minute}`);
+      }
+
+      const candidateSlots = minHHMM ? allSlots.filter((t) => t > minHHMM) : allSlots;
+      const available = candidateSlots.filter((t) => !occupied.has(t));
+
+      if (available.length === 0) continue;
+
+      const preferAfternoon = i % 2 === 1;
+      const morning = available.filter((t) => t >= settings.morning_start && t < settings.morning_end);
+      const afternoon = available.filter(
+        (t) => t >= settings.afternoon_start && t < settings.afternoon_end
+      );
+
+      const pickBase = preferAfternoon
+        ? afternoon.length
+          ? afternoon
+          : morning
+        : morning.length
+          ? morning
+          : afternoon;
+
+      const finalSlots = pickBase.slice(0, limitPerDay);
+      if (finalSlots.length === 0) continue;
+
+      if (!firstAvailableDate) firstAvailableDate = dateStr;
+
+      results.push({
+        date: dateStr,
+        available_times: finalSlots,
+        available_times_text: finalSlots.join(", "),
+      });
+
+      if (results.length >= 10) break;
+    }
+
+    const availableDaysInline = results
+      .map((d) => `${formatDDMM(d.date)}: ${d.available_times_text}`)
+      .join(" | ");
+
+    if (simple) {
+      return jsonResponse({
+        success: true,
+        horarios_disponiveis_inline: availableDaysInline,
+        horarios_disponiveis: availableDaysInline,
+        available_days_text: availableDaysInline,
+        tentativa_data: firstAvailableDate || "",
+        first_available_date: firstAvailableDate || "",
+        has_availability: results.length > 0,
+      });
+    }
+
+    return jsonResponse({
+      timezone: settings.timezone,
+      start: ymdToString(startYMD),
+      days,
+      results,
+      available_days_inline: availableDaysInline,
+      available_days_text: availableDaysInline,
+      first_available_date: firstAvailableDate || "",
+      horarios_disponiveis: availableDaysInline,
+      horarios_disponiveis_inline: availableDaysInline,
+      tentativa_data: firstAvailableDate || "",
+      success: true,
+      has_availability: results.length > 0,
+    });
+  } catch (err: any) {
+    return jsonResponse({ success: false, error: err?.message || "Internal error" }, 500);
+  }
+}

--- a/app/api/calendar/create-event/route.ts
+++ b/app/api/calendar/create-event/route.ts
@@ -1,0 +1,510 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import {
+  getCalendarWithOAuthTokens,
+  getGoogleCalendarClient,
+  getGoogleOAuthClient,
+} from "@/lib/google-calendar";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new NextResponse(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, x-api-key",
+    },
+  });
+}
+
+function normalizeText(s: string) {
+  return s?.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "") || "";
+}
+
+function parseTimeFlexible(timeStr: string) {
+  const s = normalizeText(timeStr);
+
+  const hhmm = /(?:^|\D)([01]?\d|2[0-3])[:h]([0-5]\d)(?:\D|$)/.exec(s);
+  if (hhmm) return { hh: Number(hhmm[1]), mm: Number(hhmm[2]) };
+
+  const onlyHour = /(?:^|\D)([01]?\d|2[0-3])(?:\D|$)/.exec(s);
+  if (onlyHour) return { hh: Number(onlyHour[1]), mm: 0 };
+
+  return null;
+}
+
+function getTodayPartsInTZ(timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value || 0);
+
+  return {
+    y: get("year"),
+    mo: get("month"),
+    d: get("day"),
+  };
+}
+
+function parseDateFlexibleToYMD(dateStr: string, timeZone: string) {
+  const s = normalizeText(String(dateStr)).replace(/["']/g, "");
+
+  const today = getTodayPartsInTZ(timeZone);
+
+  if (s.includes("hoje")) return today;
+
+  if (s.includes("amanha")) {
+    const dt = new Date(Date.UTC(today.y, today.mo - 1, today.d));
+    dt.setUTCDate(dt.getUTCDate() + 1);
+    return { y: dt.getUTCFullYear(), mo: dt.getUTCMonth() + 1, d: dt.getUTCDate() };
+  }
+
+  const weekdayMap: Record<string, number> = {
+    domingo: 0,
+    "dom": 0,
+    "segunda": 1,
+    "segunda-feira": 1,
+    "seg": 1,
+    "terca": 2,
+    "terça": 2,
+    "terca-feira": 2,
+    "terça-feira": 2,
+    "ter": 2,
+    "quarta": 3,
+    "quarta-feira": 3,
+    "qua": 3,
+    "quinta": 4,
+    "quinta-feira": 4,
+    "qui": 4,
+    "sexta": 5,
+    "sexta-feira": 5,
+    "sex": 5,
+    sabado: 6,
+    "sábado": 6,
+    "sab": 6,
+  };
+
+  const weekdayHit = Object.keys(weekdayMap).find((k) => s.includes(k));
+  if (weekdayHit) {
+    const target = weekdayMap[weekdayHit];
+    const todayDate = new Date(Date.UTC(today.y, today.mo - 1, today.d));
+    const short = new Intl.DateTimeFormat("en-US", { timeZone, weekday: "short" })
+      .format(todayDate)
+      .toLowerCase()
+      .replace(/[^a-z]/g, "");
+    const shortMap: Record<string, number> = {
+      sun: 0,
+      mon: 1,
+      tue: 2,
+      wed: 3,
+      thu: 4,
+      fri: 5,
+      sat: 6,
+    };
+    const currentWeekday = shortMap[short] ?? todayDate.getUTCDay();
+
+    const delta = (target - currentWeekday + 7) % 7 || 7;
+    todayDate.setUTCDate(todayDate.getUTCDate() + delta);
+    return {
+      y: todayDate.getUTCFullYear(),
+      mo: todayDate.getUTCMonth() + 1,
+      d: todayDate.getUTCDate(),
+    };
+  }
+
+  const compact = s.replace(/\s/g, "");
+
+  let m = /(\d{1,2})\/(\d{1,2})\/(\d{4})/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+  m = /(\d{1,2})-(\d{1,2})-(\d{4})/.exec(s);
+  if (m) return { y: Number(m[3]), mo: Number(m[2]), d: Number(m[1]) };
+  m = /(\d{4})-(\d{1,2})-(\d{1,2})/.exec(s);
+  if (m) return { y: Number(m[1]), mo: Number(m[2]), d: Number(m[3]) };
+
+  // dd/mm (sem ano): assume o próximo dia válido no calendário
+  m = /(\d{1,2})\/(\d{1,2})/.exec(compact);
+  if (m) {
+    const d = Number(m[1]);
+    const mo = Number(m[2]);
+    const base = new Date(Date.UTC(today.y, mo - 1, d));
+    const candidate = { y: today.y, mo, d };
+
+    const candidateStr = `${candidate.y}-${String(candidate.mo).padStart(2, "0")}-${String(candidate.d).padStart(2, "0")}`;
+    const todayStr = `${today.y}-${String(today.mo).padStart(2, "0")}-${String(today.d).padStart(2, "0")}`;
+    if (!Number.isNaN(base.getTime()) && candidateStr >= todayStr) return candidate;
+    if (!Number.isNaN(base.getTime())) return { y: today.y + 1, mo, d };
+  }
+
+  return null;
+}
+
+function getOffsetMinutes(timeZone: string, utcDate: Date) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(utcDate);
+  const get = (t: string) => Number(parts.find((p) => p.type === t)?.value);
+  const asUTC = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second")
+  );
+  return Math.round((asUTC - utcDate.getTime()) / 60000);
+}
+
+function localDateTimeToUTCISOString(
+  ymd: { y: number; mo: number; d: number },
+  hh: number,
+  mm: number,
+  timeZone: string
+) {
+  const naiveUTC = new Date(Date.UTC(ymd.y, ymd.mo - 1, ymd.d, hh, mm, 0));
+  const offset = getOffsetMinutes(timeZone, naiveUTC);
+  return new Date(naiveUTC.getTime() - offset * 60000).toISOString();
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, x-api-key",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
+
+async function getCalendarClientForUser(adminSupabase: any, userId: string) {
+  const { data: tokenRow } = await adminSupabase
+    .from("google_oauth_tokens")
+    .select("access_token, refresh_token, scope, token_type, expiry_date")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (tokenRow?.refresh_token || tokenRow?.access_token) {
+    const oauth = getGoogleOAuthClient();
+    oauth.setCredentials({
+      access_token: tokenRow.access_token || undefined,
+      refresh_token: tokenRow.refresh_token || undefined,
+      scope: tokenRow.scope || undefined,
+      token_type: tokenRow.token_type || undefined,
+      expiry_date: tokenRow.expiry_date || undefined,
+    });
+
+    if (tokenRow.refresh_token) {
+      try {
+        const refreshed = await oauth.refreshAccessToken();
+        const newTokens = refreshed.credentials;
+        await adminSupabase.from("google_oauth_tokens").upsert(
+          {
+            user_id: userId,
+            access_token: newTokens.access_token || tokenRow.access_token || null,
+            refresh_token: newTokens.refresh_token || tokenRow.refresh_token || null,
+            scope: newTokens.scope || tokenRow.scope || null,
+            token_type: newTokens.token_type || tokenRow.token_type || null,
+            expiry_date: newTokens.expiry_date || tokenRow.expiry_date || null,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "user_id" }
+        );
+      } catch {
+        // keep existing tokens
+      }
+    }
+
+    return {
+      calendar: getCalendarWithOAuthTokens(tokenRow),
+      authMode: "oauth" as const,
+    };
+  }
+
+  return {
+    calendar: getGoogleCalendarClient(),
+    authMode: "service_account" as const,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const adminSupabase = createAdminClient();
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const payload = body?.root || body;
+
+    const nomeCliente = payload?.name || payload?.nome || payload?.n || payload?.Nome || "Cliente";
+    const dataAgendamento = payload?.date || payload?.data || payload?.d;
+    const horaAgendamento = payload?.time || payload?.hora || payload?.h;
+    const telefone = payload?.phone || payload?.telefone || payload?.p || "";
+    const email = payload?.email || payload?.e || "";
+
+    const url = new URL(req.url);
+    const authHeader =
+      req.headers.get("Authorization") || req.headers.get("x-api-key") || url.searchParams.get("key");
+    const rawKey = authHeader?.replace("Bearer ", "").trim();
+    const hash = crypto.createHash("sha256").update(rawKey || "").digest("hex");
+
+    const { data: apiKeyData } = await adminSupabase
+      .from("api_keys")
+      .select("project_id")
+      .eq("key_hash", hash)
+      .single();
+
+    if (!apiKeyData) return jsonResponse({ error: "Chave API inválida" }, 401);
+
+    // tolerância para payload humano: pode vir "12/02 às 09:00" no campo data
+    const mergedForDate = `${String(dataAgendamento || "")} ${String(horaAgendamento || "")}`;
+    const mergedForTime = `${String(horaAgendamento || "")} ${String(dataAgendamento || "")}`;
+
+    const { data: dbSettings } = await adminSupabase
+      .from("schedule_settings")
+      .select("timezone, slot_minutes")
+      .eq("project_id", apiKeyData.project_id)
+      .maybeSingle();
+
+    const timeZone = dbSettings?.timezone || "America/Sao_Paulo";
+
+    const ymd = parseDateFlexibleToYMD(String(dataAgendamento || mergedForDate), timeZone);
+    const t = parseTimeFlexible(String(horaAgendamento || mergedForTime)) || parseTimeFlexible(mergedForTime);
+
+    if (!ymd || !t) {
+      return jsonResponse(
+        {
+          error: "Data ou hora inválida",
+          recebido: { data: dataAgendamento, hora: horaAgendamento },
+        },
+        400
+      );
+    }
+
+    const startISO = localDateTimeToUTCISOString(ymd, t.hh, t.mm, timeZone);
+    const endISO = new Date(
+      new Date(startISO).getTime() + (Number(dbSettings?.slot_minutes) || 60) * 60000
+    ).toISOString();
+
+    const { data: project } = await adminSupabase
+      .from("projects")
+      .select("owner_id")
+      .eq("id", apiKeyData.project_id)
+      .single();
+
+    if (!project?.owner_id) {
+      return jsonResponse({ success: false, error: "Projeto sem owner_id válido" }, 400);
+    }
+
+    // Idempotência: BotConversa pode reenviar o mesmo POST.
+    // Se já existir appointment para o mesmo cliente+horário, retornamos sucesso sem duplicar.
+    const { data: existingAppointment, error: existingErr } = await adminSupabase
+      .from("appointments")
+      .select("id, meet_link, calendar_event_id, status")
+      .eq("client_id", project.owner_id)
+      .eq("start_datetime", startISO)
+      .maybeSingle();
+
+    if (existingErr) throw new Error(`Erro Supabase (check duplicate): ${existingErr.message}`);
+
+    const shouldOnlyReturnDuplicate =
+      !!existingAppointment && (!!existingAppointment.calendar_event_id || !!existingAppointment.meet_link);
+
+    if (shouldOnlyReturnDuplicate) {
+      return jsonResponse({
+        success: true,
+        duplicate: true,
+        id: existingAppointment!.id,
+        calendar_status: "Já existia agendamento para este horário.",
+        meet_link: existingAppointment!.meet_link || null,
+        event_html_link: null,
+        calendar_auth_mode: null,
+        calendar_id_used: null,
+        google_event_status: existingAppointment!.status || null,
+        google_creator_email: null,
+        google_organizer_email: null,
+        msg: "Horário já reservado anteriormente.",
+      });
+    }
+
+    let calendar_event_id: string | null = null;
+    let meet_link: string | null = null;
+    let gcal_status = "Não conectado";
+    let event_html_link: string | null = null;
+    let calendar_auth_mode: "oauth" | "service_account" | null = null;
+    let calendar_id_used: string | null = null;
+    let google_event_status: string | null = null;
+    let google_creator_email: string | null = null;
+    let google_organizer_email: string | null = null;
+
+    try {
+      const { data: conn } = await adminSupabase
+        .from("calendar_connections")
+        .select("calendar_id")
+        .eq("user_id", project?.owner_id)
+        .maybeSingle();
+
+      if (conn?.calendar_id && project?.owner_id) {
+        const { calendar, authMode } = await getCalendarClientForUser(adminSupabase, project.owner_id);
+        calendar_auth_mode = authMode;
+        calendar_id_used = conn.calendar_id;
+
+        // Com service account, "primary" aponta para o calendário da conta de serviço,
+        // então o evento não aparece no Google Calendar do usuário.
+        if (authMode === "service_account" && conn.calendar_id === "primary") {
+          gcal_status =
+            "Google Calendar não sincronizado: conecte OAuth do usuário para usar calendar_id=primary.";
+          throw new Error(gcal_status);
+        }
+
+        const baseRequestBody = {
+          summary: `Agendamento: ${nomeCliente}`,
+          description: `Cliente: ${nomeCliente}\nTelefone: ${telefone}\nEmail: ${email}`,
+          start: { dateTime: startISO, timeZone },
+          end: { dateTime: endISO, timeZone },
+        };
+
+        try {
+          const withMeet = await calendar.events.insert({
+            calendarId: conn.calendar_id,
+            conferenceDataVersion: 1,
+            requestBody: {
+              ...baseRequestBody,
+              conferenceData: {
+                createRequest: {
+                  requestId: `meet-${Date.now()}`,
+                },
+              },
+            },
+          });
+
+          calendar_event_id = withMeet.data.id || null;
+          meet_link = withMeet.data.hangoutLink || withMeet.data.conferenceData?.entryPoints?.[0]?.uri || null;
+          event_html_link = withMeet.data.htmlLink || null;
+          google_event_status = withMeet.data.status || null;
+          google_creator_email = withMeet.data.creator?.email || null;
+          google_organizer_email = withMeet.data.organizer?.email || null;
+          gcal_status = meet_link ? "Evento + Meet criados" : "Evento criado (sem Meet)";
+        } catch (meetErr: any) {
+          console.error("Meet indisponível, criando evento sem meet:", meetErr?.message || meetErr);
+
+          const withoutMeet = await calendar.events.insert({
+            calendarId: conn.calendar_id,
+            requestBody: baseRequestBody,
+          });
+
+          calendar_event_id = withoutMeet.data.id || null;
+          meet_link = null;
+          event_html_link = withoutMeet.data.htmlLink || null;
+          google_event_status = withoutMeet.data.status || null;
+          google_creator_email = withoutMeet.data.creator?.email || null;
+          google_organizer_email = withoutMeet.data.organizer?.email || null;
+          gcal_status = "Evento criado sem Meet (fallback).";
+        }
+
+        if (calendar_event_id) {
+          try {
+            const check = await calendar.events.get({
+              calendarId: conn.calendar_id,
+              eventId: calendar_event_id,
+            });
+            google_event_status = check.data.status || google_event_status;
+            google_creator_email = check.data.creator?.email || google_creator_email;
+            google_organizer_email = check.data.organizer?.email || google_organizer_email;
+            event_html_link = check.data.htmlLink || event_html_link;
+          } catch (verifyErr: any) {
+            console.error("Evento criado, mas falhou verificação de leitura:", verifyErr?.message || verifyErr);
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error("Erro Google Calendar:", err);
+      gcal_status = `Erro Google: ${err?.message || "desconhecido"}`;
+    }
+
+    const persistPayload = {
+      project_id: apiKeyData.project_id,
+      client_id: project.owner_id,
+      start_datetime: startISO,
+      end_datetime: endISO,
+      customer_name: nomeCliente,
+      customer_phone: telefone,
+      customer_email: email || null,
+      status: "agendado",
+      calendar_event_id,
+      meet_link: meet_link || "",
+    };
+
+    const { data: appointment, error: dbErr } = existingAppointment
+      ? await adminSupabase
+          .from("appointments")
+          .update(persistPayload)
+          .eq("id", existingAppointment.id)
+          .select()
+          .single()
+      : await adminSupabase.from("appointments").insert(persistPayload).select().single();
+
+    if (dbErr) {
+      const isDuplicate = dbErr.code === "23505" || /unique_client_appointment/i.test(dbErr.message || "");
+
+      if (isDuplicate) {
+        const { data: existingAfterRace } = await adminSupabase
+          .from("appointments")
+          .select("id, meet_link, calendar_event_id, status")
+          .eq("client_id", project.owner_id)
+          .eq("start_datetime", startISO)
+          .maybeSingle();
+
+        return jsonResponse({
+          success: true,
+          duplicate: true,
+          id: existingAfterRace?.id || null,
+          calendar_status: "Já existia agendamento para este horário.",
+          meet_link: existingAfterRace?.meet_link || null,
+          event_html_link,
+          calendar_auth_mode,
+          calendar_id_used,
+          google_event_status: existingAfterRace?.status || google_event_status,
+          google_creator_email,
+          google_organizer_email,
+          msg: "Horário já reservado anteriormente.",
+        });
+      }
+
+      throw new Error(`Erro Supabase: ${dbErr.message}`);
+    }
+
+    return jsonResponse({
+      success: true,
+      recovered_existing: !!existingAppointment,
+      id: appointment.id,
+      calendar_status: gcal_status,
+      meet_link,
+      event_html_link,
+      calendar_auth_mode,
+      calendar_id_used,
+      google_event_status,
+      google_creator_email,
+      google_organizer_email,
+      msg: meet_link ? "Agendamento realizado com Meet!" : "Agendamento realizado!",
+    });
+  } catch (err: any) {
+    console.error("Erro geral:", err);
+    return jsonResponse({ success: false, error: err?.message || "Erro interno" }, 500);
+  }
+}

--- a/app/api/google/callback/route.ts
+++ b/app/api/google/callback/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGoogleOAuthClient } from "@/lib/google-calendar";
+import { createAdminClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+
+    if (!code || !state) {
+      return NextResponse.json({ error: "Parâmetros OAuth inválidos." }, { status: 400 });
+    }
+
+    const parsedState = JSON.parse(Buffer.from(state, "base64url").toString("utf8"));
+    const userId = parsedState?.userId;
+
+    if (!userId) {
+      return NextResponse.json({ error: "state inválido." }, { status: 400 });
+    }
+
+    const oauth = getGoogleOAuthClient();
+    const { tokens } = await oauth.getToken(code);
+
+    const admin = createAdminClient();
+
+    const { error } = await admin.from("google_oauth_tokens").upsert(
+      {
+        user_id: userId,
+        access_token: tokens.access_token || null,
+        refresh_token: tokens.refresh_token || null,
+        scope: tokens.scope || null,
+        token_type: tokens.token_type || null,
+        expiry_date: tokens.expiry_date || null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" }
+    );
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+    return NextResponse.redirect(`${siteUrl}/dashboard?google=connected`);
+  } catch (err: any) {
+    return NextResponse.json({ error: err?.message || "Falha no callback OAuth" }, { status: 500 });
+  }
+}

--- a/app/api/google/connect/route.ts
+++ b/app/api/google/connect/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGoogleOAuthClient } from "@/lib/google-calendar";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+  }
+
+  const oauth = getGoogleOAuthClient();
+  const state = Buffer.from(JSON.stringify({ userId: user.id })).toString("base64url");
+
+  const url = oauth.generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: true,
+    scope: [
+      "https://www.googleapis.com/auth/calendar",
+      "https://www.googleapis.com/auth/calendar.events",
+    ],
+    state,
+  });
+
+  return NextResponse.redirect(url);
+}

--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  return new NextResponse(JSON.stringify({ ok: true, ts: Date.now() }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/api/portal-session/route.ts
+++ b/app/api/portal-session/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { createClient } from "@/lib/supabase/server";
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+if (!stripeSecretKey) {
+  throw new Error("STRIPE_SECRET_KEY não configurada.");
+}
+
+if (!siteUrl) {
+  throw new Error("NEXT_PUBLIC_SITE_URL não configurada.");
+}
+
+const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2025-02-24.acacia",
+});
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError) {
+      return NextResponse.json({ error: authError.message }, { status: 401 });
+    }
+
+    if (!user) {
+      return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("stripe_customer_id")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    if (!profile?.stripe_customer_id) {
+      return NextResponse.json({ error: "Cliente Stripe não encontrado" }, { status: 404 });
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: profile.stripe_customer_id,
+      return_url: `${siteUrl}/dashboard`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : "Erro inesperado ao criar sessão do portal de cobrança.";
+    console.error("[PORTAL_ERROR]:", err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/docs/supabase-security-checklist.md
+++ b/docs/supabase-security-checklist.md
@@ -1,0 +1,35 @@
+# Supabase Security Advisor Fix Checklist
+
+Use this checklist after running `supabase/security-hardening.sql`.
+
+## 1) Run SQL hardening script
+
+- Open Supabase SQL Editor.
+- Run `supabase/security-hardening.sql`.
+- Re-open Security Advisor and confirm critical items are gone.
+
+## 2) Dashboard-only settings (not SQL)
+
+Some alerts cannot be fixed from your app code/migrations:
+
+- **Leaked Password Protection Disabled**
+  - Supabase Dashboard -> Authentication -> Providers -> Email
+  - Enable leaked password protection.
+
+## 3) RLS policy review
+
+If you still see warnings like "Multiple Permissive Policies", keep only the minimum policies needed.
+
+Practical approach:
+
+1. Open the table in Security Advisor message.
+2. Compare all policies for that table.
+3. Remove overlapping permissive policies when one policy already covers the same access.
+
+## 4) Performance warnings (Auth RLS Initialization Plan)
+
+These are performance hints, not direct data leaks. Tuning options:
+
+- Ensure indexes exist on columns used in policies (`user_id`, `project_id`, etc.).
+- Keep policy predicates simple.
+- Prefer direct comparisons (`user_id = auth.uid()`) over large nested subqueries where possible.

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -1,0 +1,54 @@
+import { google } from "googleapis";
+
+export function getGoogleCalendarClient() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON || "{}");
+
+  if (!credentials.private_key || !credentials.client_email) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_JSON não configurado corretamente.");
+  }
+
+  const formattedKey = credentials.private_key.replace(/\\n/g, "\n");
+
+  const auth = new google.auth.JWT(
+    credentials.client_email,
+    undefined,
+    formattedKey,
+    [
+      "https://www.googleapis.com/auth/calendar",
+      "https://www.googleapis.com/auth/calendar.events",
+    ]
+  );
+
+  return google.calendar({ version: "v3", auth });
+}
+
+export function getGoogleOAuthClient() {
+  const clientId = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const redirectUri = process.env.GOOGLE_OAUTH_REDIRECT_URI;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new Error("Variáveis GOOGLE_OAUTH_CLIENT_ID/SECRET/REDIRECT_URI não configuradas.");
+  }
+
+  return new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+}
+
+export function getCalendarWithOAuthTokens(tokens: {
+  access_token?: string | null;
+  refresh_token?: string | null;
+  scope?: string | null;
+  token_type?: string | null;
+  expiry_date?: number | null;
+}) {
+  const auth = getGoogleOAuthClient();
+  auth.setCredentials({
+    access_token: tokens.access_token || undefined,
+    refresh_token: tokens.refresh_token || undefined,
+    scope: tokens.scope || undefined,
+    token_type: tokens.token_type || undefined,
+    expiry_date: tokens.expiry_date || undefined,
+  });
+
+  return google.calendar({ version: "v3", auth });
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,59 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch {
+            // no-op
+          }
+        },
+        remove(name: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: "", ...options });
+          } catch {
+            // no-op
+          }
+        },
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach((cookie) => cookieStore.set(cookie));
+          } catch {
+            // no-op
+          }
+        },
+      },
+    }
+  );
+}
+
+export function createAdminClient() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return [];
+        },
+        setAll() {
+          // no-op
+        },
+      },
+    }
+  );
+}

--- a/supabase/security-hardening.sql
+++ b/supabase/security-hardening.sql
@@ -1,0 +1,90 @@
+-- Security hardening for Supabase Security Advisor findings
+-- Safe to run multiple times (idempotent where possible).
+
+begin;
+
+-- 1) Ensure RLS is enabled for tables flagged as critical.
+alter table if exists public.schedule_settings enable row level security;
+alter table if exists public.subscriptions enable row level security;
+
+-- 2) Add baseline policies for tables that often miss policies.
+--    Adjust these rules to match your business rules if needed.
+do $$
+begin
+  if to_regclass('public.schedule_settings') is not null then
+    if not exists (
+      select 1
+      from pg_policies
+      where schemaname = 'public'
+        and tablename = 'schedule_settings'
+        and policyname = 'Users manage own schedule settings'
+    ) then
+      create policy "Users manage own schedule settings"
+      on public.schedule_settings
+      for all
+      using (
+        exists (
+          select 1
+          from public.projects p
+          where p.id = schedule_settings.project_id
+            and p.owner_id = auth.uid()
+        )
+        or public.is_gestor()
+      )
+      with check (
+        exists (
+          select 1
+          from public.projects p
+          where p.id = schedule_settings.project_id
+            and p.owner_id = auth.uid()
+        )
+        or public.is_gestor()
+      );
+    end if;
+  end if;
+
+  if to_regclass('public.subscriptions') is not null then
+    if not exists (
+      select 1
+      from pg_policies
+      where schemaname = 'public'
+        and tablename = 'subscriptions'
+        and policyname = 'Users manage own subscriptions'
+    ) then
+      create policy "Users manage own subscriptions"
+      on public.subscriptions
+      for all
+      using (
+        user_id = auth.uid()
+        or public.is_gestor()
+      )
+      with check (
+        user_id = auth.uid()
+        or public.is_gestor()
+      );
+    end if;
+  end if;
+end $$;
+
+-- 3) Lock down search_path for Security Advisor "Function Search Path Mutable" warnings.
+--    Only apply if function exists.
+do $$
+begin
+  if to_regprocedure('public.is_gestor()') is not null then
+    alter function public.is_gestor() set search_path = public, pg_temp;
+  end if;
+
+  if to_regprocedure('public.handle_new_user_create_project()') is not null then
+    alter function public.handle_new_user_create_project() set search_path = public, pg_temp;
+  end if;
+
+  if to_regprocedure('public.set_updated_at_google_oauth_tokens()') is not null then
+    alter function public.set_updated_at_google_oauth_tokens() set search_path = public, pg_temp;
+  end if;
+
+  if to_regprocedure('public.handle_new_user()') is not null then
+    alter function public.handle_new_user() set search_path = public, pg_temp;
+  end if;
+end $$;
+
+commit;


### PR DESCRIPTION
### Motivation
- BotConversa payloads using human date formats like `13-02-2026` were rejected with `Data ou hora inválida`, breaking real bookings.
- The previous idempotency early-return could skip calendar synchronization when an appointment row existed in Supabase but had no Google calendar linkage.
- The route must be idempotent for true retries while still creating/updating calendar linkage for existing DB rows that lack it.

### Description
- Accept `DD-MM-YYYY` in the flexible date parser and keep existing formats, so human dates like `13-02-2026` parse correctly in `app/api/calendar/create-event/route.ts`.
- Change duplicate handling to immediately return `duplicate` only when the existing appointment already has `calendar_event_id` or `meet_link`, otherwise continue to create the Google Calendar event and update the existing row instead of no-oping.
- Use an update-when-existing / insert-when-new flow and preserve race-condition detection for Postgres `23505` / `unique_client_appointment` collisions to return success instead of 500; add `recovered_existing` flag in the response when an existing row is updated.
- Add supporting files and endpoints for availability, Google OAuth and server helpers: `lib/google-calendar.ts`, `lib/supabase/server.ts`, `/api/calendar/available-days*`, `/api/calendar/available-times`, `/api/google/connect`, `/api/google/callback`, `/api/ping`, billing portal/portal-session endpoints, docs and `supabase/security-hardening.sql` as part of the rollout.

### Testing
- Verified the modified `create-event` logic by inspecting the file with `nl -ba app/api/calendar/create-event/route.ts | sed -n '120,170p;300,530p'` which showed the updated parsing and idempotency branches and succeeded.
- Committed the patch with `git status -sb && git add app/api/calendar/create-event/route.ts && git commit -m "Fix create-event date parsing and recover calendar sync on existing slot"` and created the PR programmatically, all commands completed successfully.
- No automated unit test suite was present for these endpoints, so validation consisted of deterministic file-level inspections and successful patch/commit operations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987f00f18a8833390c723e61b7a0986)